### PR TITLE
Adding podspec for PKHUD

### DIFF
--- a/PKHUD.podspec
+++ b/PKHUD.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name                      = 'PKHUD'
+  s.module_name               = 'PKHUD'
+  s.version                   = '1.0.0'
+  s.summary                   = 'A Swift based reimplementation of the Apple HUD (Volume, Ringer, Rotation,…) for iOS 8'
+  s.homepage                  = 'https://github.com/pkluz/PKHUD'
+  s.license                   = 'MIT'
+  s.author                    = { 'Philip Kluz' => 'Philip.Kluz@gmail.com' }
+  s.platform                  = :ios, '8.0'
+  s.ios.deployment_target     = '8.0'
+  s.requires_arc              = true
+  s.source                    = { :git => 'https://github.com/pkluz/PKHUD.git', :tag => '1.0.0' }
+  s.source_files              = 'PKHUD/**/*.{h,swift}'
+  s.resources                 = 'PKHUD/*.xcassets'
+end


### PR DESCRIPTION
Adding podspec that will allow installing PKHUD via CocoaPods. NOTE: In order to install PKHUD as a framework, you must be using CocoaPods 0.36 beta.

@pkluz After accepting this PR, you should create a release for PKHUD (e.g. release 1.0.0) or alter the podspec as you see fit. You can register this podspec with CocoaPods repo if you want to install it like:

```ruby
pod 'PKHUD', '~> 1.0.0'
```
If you do not want to register the spec (and maintain pushing updated pod specs there) you can always target git tags

```ruby
pod 'PKHUD', :git => 'https://github.com/pkluz/PKHUD.git', :tag => '1.0.0'
```