### PR TITLE
Add HUD: static wrapper for PKHUD with streamlined usage syntax

### DIFF
--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -13,50 +13,35 @@ class DemoViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        PKHUD.sharedHUD.dimsBackground = false
-        PKHUD.sharedHUD.userInteractionOnUnderlyingViewsEnabled = false
+        HUD.dimsBackground = false
+        HUD.allowsInteraction = false
     }
 
     @IBAction func showAnimatedSuccessHUD(sender: AnyObject) {
-        PKHUD.sharedHUD.contentView = PKHUDSuccessView()
-        PKHUD.sharedHUD.show()
-        PKHUD.sharedHUD.hide(afterDelay: 2.0);
+        HUD.flash(.Success, withDelay: 2.0)
     }
     
     @IBAction func showAnimatedErrorHUD(sender: AnyObject) {
-        PKHUD.sharedHUD.contentView = PKHUDErrorView()
-        PKHUD.sharedHUD.show()
-        PKHUD.sharedHUD.hide(afterDelay: 2.0);
+        HUD.flash(.Failure, withDelay: 2.0)
     }
     
     @IBAction func showAnimatedProgressHUD(sender: AnyObject) {
-        PKHUD.sharedHUD.contentView = PKHUDProgressView()
-        PKHUD.sharedHUD.show()
-        
-        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(2.0 * Double(NSEC_PER_SEC)))
-        dispatch_after(delayTime, dispatch_get_main_queue()) {
-            PKHUD.sharedHUD.contentView = PKHUDSuccessView()
-            PKHUD.sharedHUD.hide(afterDelay: 2.0)
+        HUD.show(.Progress)
+     
+        delay(2.0) {
+            HUD.flash(.Success, withDelay: 2.0)
         }
     }
     
     @IBAction func showAnimatedStatusProgressHUD(sender: AnyObject) {
-        PKHUD.sharedHUD.contentView = PKHUDStatusProgressView(title: "Title", subtitle: "Subtitle goes here")
-        PKHUD.sharedHUD.show()
-        PKHUD.sharedHUD.hide(afterDelay: 2.0);
-        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(2.0 * Double(NSEC_PER_SEC)))
-        dispatch_after(delayTime, dispatch_get_main_queue()) {
-            PKHUD.sharedHUD.contentView = PKHUDSuccessView()
-            PKHUD.sharedHUD.hide(afterDelay: 2.0)
+        HUD.flash(.StatusProgress(title: "Title", subtitle: "Subtitle goes here"), withDelay: 2.0)
+        delay(2.0) {
+            HUD.flash(.Success)
         }
-
     }
 
-    
     @IBAction func showTextHUD(sender: AnyObject) {
-        PKHUD.sharedHUD.contentView = PKHUDTextView(text: "Requesting Licence…")
-        PKHUD.sharedHUD.show()
-        PKHUD.sharedHUD.hide(afterDelay: 2.0)
+        HUD.flash(.Text("Requesting Licence…"), withDelay: 2.0)
     }
     
     override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
@@ -65,5 +50,14 @@ class DemoViewController: UIViewController {
     
     override func preferredStatusBarStyle() -> UIStatusBarStyle {
         return .LightContent
+    }
+    
+    func delay(delay:Double, closure:()->()) {
+        dispatch_after(
+            dispatch_time(
+                DISPATCH_TIME_NOW,
+                Int64(delay * Double(NSEC_PER_SEC))
+            ),
+            dispatch_get_main_queue(), closure)
     }
 }

--- a/PKHUD.xcodeproj/project.pbxproj
+++ b/PKHUD.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		12010C881C3C42A7005DC6FC /* PKHUDStatusProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12010C871C3C42A7005DC6FC /* PKHUDStatusProgressView.swift */; };
 		12010C8A1C3D0E8D005DC6FC /* PKHUDAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12010C891C3D0E8D005DC6FC /* PKHUDAnimation.swift */; };
+		640011571C5B6C080013F32B /* HUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640011551C5B6C080013F32B /* HUD.swift */; };
 		F908BEC01BB849290015E5A8 /* PKHUDSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F908BEBF1BB849290015E5A8 /* PKHUDSuccessView.swift */; };
 		F908BEC31BB84D0B0015E5A8 /* PKHUDAnimating.swift in Sources */ = {isa = PBXBuildFile; fileRef = F908BEC21BB84D0B0015E5A8 /* PKHUDAnimating.swift */; };
 		F908BEC51BB852C60015E5A8 /* PKHUDErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F908BEC41BB852C60015E5A8 /* PKHUDErrorView.swift */; };
@@ -71,6 +72,7 @@
 /* Begin PBXFileReference section */
 		12010C871C3C42A7005DC6FC /* PKHUDStatusProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKHUDStatusProgressView.swift; sourceTree = "<group>"; };
 		12010C891C3D0E8D005DC6FC /* PKHUDAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKHUDAnimation.swift; sourceTree = "<group>"; };
+		640011551C5B6C080013F32B /* HUD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HUD.swift; sourceTree = "<group>"; };
 		F908BEBF1BB849290015E5A8 /* PKHUDSuccessView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKHUDSuccessView.swift; sourceTree = "<group>"; };
 		F908BEC21BB84D0B0015E5A8 /* PKHUDAnimating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKHUDAnimating.swift; sourceTree = "<group>"; };
 		F908BEC41BB852C60015E5A8 /* PKHUDErrorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKHUDErrorView.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 		F996321F19514FD8001F73CA /* PKHUD */ = {
 			isa = PBXGroup;
 			children = (
+				640011551C5B6C080013F32B /* HUD.swift */,
 				F996322219514FD8001F73CA /* PKHUD.h */,
 				F996324819514FEF001F73CA /* PKHUD.swift */,
 				F996324619514FEF001F73CA /* PKHUDAssets.swift */,
@@ -345,6 +348,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F996325019514FEF001F73CA /* FrameView.swift in Sources */,
+				640011571C5B6C080013F32B /* HUD.swift in Sources */,
 				F935B1631B2B8CE2003C3734 /* PKHUDImageView.swift in Sources */,
 				12010C881C3C42A7005DC6FC /* PKHUDStatusProgressView.swift in Sources */,
 				F935B1611B2B8C8E003C3734 /* PKHUDTextView.swift in Sources */,

--- a/PKHUD/HUD.swift
+++ b/PKHUD/HUD.swift
@@ -1,0 +1,86 @@
+//
+//  Created by Eugene Tartakovsky on 29/01/16.
+//  Copyright © 2016 Eugene Tartakovsky. All rights reserved.
+//
+
+import UIKit
+import PKHUD
+
+public enum HUDContent {
+    case Success
+    case Failure
+    case Progress
+    case Text(String)
+    case Image(UIImage)
+    case Status(title: String, subtitle: String, image: UIImage)
+    case StatusProgress(title: String, subtitle: String)
+    case Title(title: String, image: UIImage)
+    case Subtitle(subtitle: String, image: UIImage)
+    case SystemActivity
+}
+
+public final class HUD {
+    // MARK: Properties
+    public static var dimsBackground: Bool {
+        get { return PKHUD.sharedHUD.dimsBackground }
+        set { PKHUD.sharedHUD.dimsBackground = newValue }
+    }
+    
+    public static var allowsInteraction: Bool {
+        get { return PKHUD.sharedHUD.userInteractionOnUnderlyingViewsEnabled  }
+        set { PKHUD.sharedHUD.userInteractionOnUnderlyingViewsEnabled = newValue }
+    }
+    
+    public static var isVisible: Bool { return PKHUD.sharedHUD.isVisible }
+    
+    // MARK: Public methods, PKHUD based
+    public static func show(content: HUDContent) {
+        PKHUD.sharedHUD.contentView = contentView(content)
+        PKHUD.sharedHUD.show()
+    }
+    
+    public static func hide(animated animated: Bool = false) {
+        PKHUD.sharedHUD.hide(animated: animated)
+    }
+    
+    public static func hide(afterDelay delay: NSTimeInterval) {
+        PKHUD.sharedHUD.hide(afterDelay: delay)
+    }
+    
+    // MARK: Public methods, HUD based
+    public static func flash(content: HUDContent) {
+        HUD.show(content)
+        HUD.hide(animated: true)
+    }
+    
+    public static func flash(content: HUDContent, withDelay delay: NSTimeInterval) {
+        HUD.show(content)
+        HUD.hide(afterDelay: delay)
+    }
+    
+    // MARK: Private methods
+    private static func contentView(content: HUDContent) -> UIView {
+        switch content {
+        case .Success:
+            return PKHUDSuccessView()
+        case .Failure:
+            return PKHUDErrorView()
+        case .Progress:
+            return PKHUDProgressView()
+        case let .Text(text):
+            return PKHUDTextView(text: text)
+        case let .Image(image):
+            return PKHUDImageView(image: image)
+        case let .Status(title, subtitle, image):
+            return PKHUDStatusView(title: title, subtitle: subtitle, image: image)
+        case let .StatusProgress(title: title, subtitle: subtitle):
+            return PKHUDStatusProgressView(title: title, subtitle: subtitle)
+        case let .Title(title, image):
+            return PKHUDTitleView(title: title, image: image)
+        case let .Subtitle(subtitle, image):
+            return PKHUDSubtitleView(subtitle: subtitle, image: image)
+        case .SystemActivity:
+            return PKHUDSystemActivityIndicatorView()
+        }
+    }
+}


### PR DESCRIPTION
Hi @pkluz,

Thanks for the PKHUD. It's still the best HUD library out there. We are using it in our production projects here at [Masslight](http://masslight.com/). 

The syntax of PKHUD is slightly verbose, so i created a wrapper to simplify it's usage. Hope it will help :)

Here are some examples:
**Show:**
Before: 
```
PKHUD.sharedHUD.contentView = PKHUDProgressView()
PKHUD.sharedHUD.show()
```

After:
```
HUD.show(.Progress)
```

**Hide:**
Before:
```
PKHUD.sharedHUD.hide(animated: false)
PKHUD.sharedHUD.hide()
PKHUD.sharedHUD.hide(afterDelay: 2.0)
```

After:
```
HUD.hide()
HUD.hide(animated: true)
HUD.hide(afterDelay: 2.0)
```

**Show content and hide**
Before:
```
PKHUD.sharedHUD.contentView = PKHUDSuccessView()
PKHUD.sharedHUD.show()
PKHUD.sharedHUD.hide()
```

After:
```
HUD.flash(.Success)
```

**Show content and hide after delay:**
Before
```
PKHUD.sharedHUD.contentView = PKHUDErrorView()
PKHUD.sharedHUD.show()
PKHUD.sharedHUD.hide(afterDelay: 2.0);
```

After: 
```
HUD.flash(.Failure, withDelay: 2.0)
```

**Show contentView with parameters and hide animated**
Before:
```
PKHUD.sharedHUD.contentView = PKHUDStatusProgressView(title: "Title", subtitle: "Subtitle goes here")
PKHUD.sharedHUD.show()
PKHUD.sharedHUD.hide(afterDelay: 2.0)
```

After:
```
HUD.flash(.StatusProgress(title: "Title", subtitle: "Subtitle goes here"), withDelay: 2.0)
```
