### PR TITLE
Fixes a lockup where resignKeyWindow was failing to be called.

### DIFF
--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -31,7 +31,7 @@ public class PKHUD: NSObject {
     public override init () {
         super.init()
         NSNotificationCenter.defaultCenter().addObserver(self,
-            selector: Selector("willEnterForeground:"),
+            selector: #selector(PKHUD.willEnterForeground(_:)),
             name: UIApplicationWillEnterForegroundNotification,
             object: nil)
         userInteractionOnUnderlyingViewsEnabled = false
@@ -98,7 +98,7 @@ public class PKHUD: NSObject {
         hideTimer?.invalidate()
         hideTimer = NSTimer.scheduledTimerWithTimeInterval(delay,
                                                            target: self,
-                                                           selector: Selector("performDelayedHide:"),
+                                                           selector: #selector(PKHUD.performDelayedHide(_:)),
                                                            userInfo: userInfo,
                                                            repeats: false)
     }

--- a/PKHUD/PKHUDSquareBaseView.swift
+++ b/PKHUD/PKHUDSquareBaseView.swift
@@ -46,6 +46,8 @@ public class PKHUDSquareBaseView: UIView {
         label.textAlignment = .Center
         label.font = UIFont.boldSystemFontOfSize(17.0)
         label.textColor = UIColor.blackColor().colorWithAlphaComponent(0.85)
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.25
         return label
     }()
     
@@ -56,6 +58,8 @@ public class PKHUDSquareBaseView: UIView {
         label.textColor = UIColor.blackColor().colorWithAlphaComponent(0.7)
         label.adjustsFontSizeToFitWidth = true
         label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.25
         return label
     }()
     

--- a/PKHUD/Window.swift
+++ b/PKHUD/Window.swift
@@ -72,7 +72,7 @@ internal class Window: UIWindow {
             UIView.animateWithDuration(0.8, animations: {
                 self.frameView.alpha = 0.0
                 self.hideBackground(animated: false)
-            }, completion: finalize)
+            }, completion: { bool in finalize(finished: true) } )
         } else {
             self.frameView.alpha = 0.0
             finalize(finished: true)


### PR DESCRIPTION
This fixes a lockup that can occur when the HUD is in the process of displaying when the application resigns active.  For reasons that are not clear to me, when the application is resigning active the code path changes to not go through the usual finalize call without animation.  Eventually the call at the end of the animation completion block is made, but fails to pass a finished parameter (I don't know why you'd ever not want to finish), which was causing the window to not resignKeyWindow and block user interaction permanently.