### PR TITLE
Fixed issue when using PKHUD.sharedHUD.hide(), compiler was complaini…

### DIFF
--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -88,7 +88,11 @@ public class PKHUD: NSObject {
         stopAnimatingContentView()
     }
     
-    public func hide(afterDelay delay: NSTimeInterval = 1.0, completion: TimerAction? = nil) {
+    public func hide(animated: Bool, completion: TimerAction? = nil) {
+        hide(animated: animated, completion: completion)
+    }
+    
+    public func hide(afterDelay delay: NSTimeInterval, completion: TimerAction? = nil) {
         let key = NSUUID().UUIDString
         let userInfo = ["timerActionKey": key]
         if let completion = completion {


### PR DESCRIPTION
…ng about ambiguous hide method

This issues was fixed by PR #73 but somehow it got replaced. It only happens if you use PKHUD.sharedHUD.hide() 