### PR TITLE
Changed to #selector() syntax

### DIFF
--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -31,7 +31,7 @@ public class PKHUD: NSObject {
     public override init () {
         super.init()
         NSNotificationCenter.defaultCenter().addObserver(self,
-            selector: Selector("willEnterForeground:"),
+            selector: #selector(PKHUD.willEnterForeground(_:)),
             name: UIApplicationWillEnterForegroundNotification,
             object: nil)
         userInteractionOnUnderlyingViewsEnabled = false
@@ -98,7 +98,7 @@ public class PKHUD: NSObject {
         hideTimer?.invalidate()
         hideTimer = NSTimer.scheduledTimerWithTimeInterval(delay,
                                                            target: self,
-                                                           selector: Selector("performDelayedHide:"),
+                                                           selector: #selector(PKHUD.performDelayedHide(_:)),
                                                            userInfo: userInfo,
                                                            repeats: false)
     }


### PR DESCRIPTION
Small fix to remove warnings when building with Xcode 7.3 / swift-2.2. Not sure if master is the best target branch for this, I'm guessing that should also support older versions. Let me know and I'll update it for another branch.