### PR TITLE
Allow labels to adjust in size so that they always fit.

### DIFF
--- a/PKHUD/PKHUDSquareBaseView.swift
+++ b/PKHUD/PKHUDSquareBaseView.swift
@@ -46,6 +46,8 @@ public class PKHUDSquareBaseView: UIView {
         label.textAlignment = .Center
         label.font = UIFont.boldSystemFontOfSize(17.0)
         label.textColor = UIColor.blackColor().colorWithAlphaComponent(0.85)
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.25
         return label
     }()
     
@@ -56,6 +58,8 @@ public class PKHUDSquareBaseView: UIView {
         label.textColor = UIColor.blackColor().colorWithAlphaComponent(0.7)
         label.adjustsFontSizeToFitWidth = true
         label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.25
         return label
     }()
     


### PR DESCRIPTION
Labels will scale down to 0.25 their normal size, but still fit.