### PR TITLE
Fix for Swift 3: methods from public protocol must be public

### DIFF
--- a/PKHUD/PKHUDErrorView.swift
+++ b/PKHUD/PKHUDErrorView.swift
@@ -68,7 +68,7 @@ open class PKHUDErrorView: PKHUDSquareBaseView, PKHUDAnimating {
         return animation
     }
 
-    func startAnimation() {
+    public func startAnimation() {
         let dashOneAnimation = rotationAnimation(-45.0)
         let dashTwoAnimation = rotationAnimation(45.0)
 
@@ -79,7 +79,7 @@ open class PKHUDErrorView: PKHUDSquareBaseView, PKHUDAnimating {
         dashTwoLayer.add(dashTwoAnimation, forKey: "dashTwoAnimation")
     }
 
-    func stopAnimation() {
+    public func stopAnimation() {
         dashOneLayer.removeAnimation(forKey: "dashOneAnimation")
         dashTwoLayer.removeAnimation(forKey: "dashTwoAnimation")
     }

--- a/PKHUD/PKHUDProgressView.swift
+++ b/PKHUD/PKHUDProgressView.swift
@@ -21,10 +21,10 @@ open class PKHUDProgressView: PKHUDSquareBaseView, PKHUDAnimating {
         super.init(coder: aDecoder)
     }
 
-    func startAnimation() {
+    public func startAnimation() {
         imageView.layer.add(PKHUDAnimation.discreteRotation, forKey: "progressAnimation")
     }
 
-    func stopAnimation() {
+    public func stopAnimation() {
     }
 }

--- a/PKHUD/PKHUDRotatingImageView.swift
+++ b/PKHUD/PKHUDRotatingImageView.swift
@@ -10,13 +10,13 @@
 import UIKit
 import QuartzCore
 
-/// PKHUDRotatingImageView provides a content view that rotates the supplies image automatically.
+/// PKHUDRotatingImageView provides a content view that rotates the supplied image automatically.
 open class PKHUDRotatingImageView: PKHUDSquareBaseView, PKHUDAnimating {
 
-    func startAnimation() {
+    public func startAnimation() {
         imageView.layer.add(PKHUDAnimation.continuousRotation, forKey: "progressAnimation")
     }
 
-    func stopAnimation() {
+    public func stopAnimation() {
     }
 }

--- a/PKHUD/PKHUDSystemActivityIndicatorView.swift
+++ b/PKHUD/PKHUDSystemActivityIndicatorView.swift
@@ -45,7 +45,7 @@ public final class PKHUDSystemActivityIndicatorView: PKHUDSquareBaseView, PKHUDA
         return activity
     }()
 
-    func startAnimation() {
+    public func startAnimation() {
         activityIndicatorView.startAnimating()
     }
 }


### PR DESCRIPTION
makes all project targets compile for swift 3 in Xcode 8.2.1. 

https://github.com/pkluz/PKHUD/commit/7d1802e90c7ee6adf941741a6bc80f5c10352210 made the animating protocol public, but did not update all conforming types to also mark their methods public. This broke master for Swift 3. 

~~The Swiftlint addition (https://github.com/pkluz/PKHUD/commit/3098b1ca46e69e3eac1e9894b569138c252bc64e) combined badly with Swift 3 migration changes for the `_content` property, breaking the demo app.~~ This was wrong, I needed to update my local swiftlint instead. One improvement to catch this might be a version check in the swiftlint build phase step, though that'd require manual updating.

### Test Steps
* To test, pull this branch and ensure all targets build. 
* Run the demo app and tap through the various options, ensuring a HUD shows up and animates as expected each time.
* Unfortunately there is no test suite for the project currently. I considered adding one for this PR but that is a larger scope of changes and I think it belongs in a separate PR. We should add at least minimal coverage so that things like compile errors get caught immediately. 
* Ideally if you have a project with PKHUD as a dependency, also update your project to use this branch and ensure that HUDs still appear and behave as expected.
