### PR TITLE
Add grace time support

### DIFF
--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -187,7 +187,6 @@ open class PKHUD: NSObject {
 
     internal func handleGraceTimer(_ timer: Timer? = nil) {
         // Show the HUD only if the task is still running
-
         if !finished {
             showContent()
         }

--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -116,11 +116,15 @@ open class PKHUD: NSObject {
             RunLoop.current.add(timer, forMode: .commonModes)
             graceTimer = timer
         }else{
-            container.showFrameView()
-            startAnimatingContentView()
+            showContent()
         }
     }
 
+    func showContent() {
+        container.showFrameView()
+        startAnimatingContentView()
+    }
+    
     open func hide(animated anim: Bool = true, completion: TimerAction? = nil) {
         graceTimer?.invalidate()
         finished = true
@@ -185,8 +189,7 @@ open class PKHUD: NSObject {
         // Show the HUD only if the task is still running
 
         if !finished {
-            container.showFrameView()
-            startAnimatingContentView()
+            showContent()
         }
     }
 }

--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -24,8 +24,6 @@ open class PKHUD: NSObject {
     public typealias TimerAction = (Bool) -> Void
     fileprivate var timerActions = [String: TimerAction]()
 
-    var finished = false
-
     /// Grace period is the time (in seconds) that the invoked method may be run without
     /// showing the HUD. If the task finishes before the grace time runs out, the HUD will
     /// not be shown at all.
@@ -108,8 +106,6 @@ open class PKHUD: NSObject {
             container.showBackground(animated: true)
         }
 
-        finished = false
-
         // If the grace time is set, postpone the HUD display
         if graceTime > 0.0 {
             let timer = Timer(timeInterval: graceTime, target: self, selector: #selector(PKHUD.handleGraceTimer(_:)), userInfo: nil, repeats: false)
@@ -127,7 +123,6 @@ open class PKHUD: NSObject {
     
     open func hide(animated anim: Bool = true, completion: TimerAction? = nil) {
         graceTimer?.invalidate()
-        finished = true
 
         container.hideFrameView(animated: anim, completion: completion)
         stopAnimatingContentView()
@@ -187,7 +182,7 @@ open class PKHUD: NSObject {
 
     internal func handleGraceTimer(_ timer: Timer? = nil) {
         // Show the HUD only if the task is still running
-        if !finished {
+        if (graceTimer?.isValid)! {
             showContent()
         }
     }

--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -117,6 +117,7 @@ open class PKHUD: NSObject {
     }
 
     func showContent() {
+        graceTimer?.invalidate()
         container.showFrameView()
         startAnimatingContentView()
     }


### PR DESCRIPTION
Grace period is the time (in seconds) that the invoked method may be run without showing the HUD. If the task finishes before the grace time runs out, the HUD will not be shown at all. This may be used to prevent HUD display for very short tasks. Defaults to 0 (no grace time). like MBProgressHUD.