### PR TITLE
Set Window isHidden to True on Init

### DIFF
--- a/PKHUD/Window.swift
+++ b/PKHUD/Window.swift
@@ -27,6 +27,7 @@ internal class ContainerView: UIView {
 
     fileprivate func commonInit() {
         backgroundColor = UIColor.clear
+        isHidden = true
 
         addSubview(backgroundView)
         addSubview(frameView)

--- a/PKHUDDemoUITests/PKHUDDemoUITests.swift
+++ b/PKHUDDemoUITests/PKHUDDemoUITests.swift
@@ -59,7 +59,7 @@ class PKHUDUITests: XCTestCase {
         self.waitForHudToDisappear()
     }
 
-    func waitForCondition(element: XCUIElement, predicate: NSPredicate, timeout: TimeInterval = 5) {
+    func waitForCondition(element: XCUIElement, predicate: NSPredicate, timeout: TimeInterval = 3          ) {
         expectation(for: predicate, evaluatedWith: element, handler:nil)
         waitForExpectations(timeout: timeout, handler: nil)
     }

--- a/PKHUDDemoUITests/PKHUDDemoUITests.swift
+++ b/PKHUDDemoUITests/PKHUDDemoUITests.swift
@@ -59,7 +59,7 @@ class PKHUDUITests: XCTestCase {
         self.waitForHudToDisappear()
     }
 
-    func waitForCondition(element: XCUIElement, predicate: NSPredicate, timeout: TimeInterval = 3          ) {
+    func waitForCondition(element: XCUIElement, predicate: NSPredicate, timeout: TimeInterval = 3.5) {
         expectation(for: predicate, evaluatedWith: element, handler:nil)
         waitForExpectations(timeout: timeout, handler: nil)
     }


### PR DESCRIPTION
When HUD first get initialized, it is not hidden. As a result, checking `HUD.isVisible` returns true even though it has **never** been presented. Setting `isHidden` to `true` on `Window.swift` resolves this.

The particular case I am addressing is for deeplinking into an app. I only want to proceed with the deep link if there is not a non-interruptible operation in progress (easily identified by a visible HUD).
