### PR TITLE
Add unit test for initial isVisible

### DIFF
--- a/PKHUDDemoUITests/PKHUDDemoUITests.swift
+++ b/PKHUDDemoUITests/PKHUDDemoUITests.swift
@@ -23,6 +23,10 @@ class PKHUDUITests: XCTestCase {
         super.tearDown()
     }
 
+    func testAAAExpectIsVisibleToBeInitiallyFalse() {
+        XCTAssert(!PKHUD.sharedHUD.isVisible)
+    }
+
     func testAnimatedSuccessHUD() {
         app.buttons["Animated Success HUD"].tap()
         self.waitForHudToAppear()

--- a/PKHUDDemoUITests/PKHUDDemoUITests.swift
+++ b/PKHUDDemoUITests/PKHUDDemoUITests.swift
@@ -23,6 +23,10 @@ class PKHUDUITests: XCTestCase {
         super.tearDown()
     }
 
+    // This test checks the initial isVisible value.
+    // To ensure it runs first (before any other test might
+    // have changed the sharedHUD state), it is prefixed
+    // with three "A"s
     func testAAAExpectIsVisibleToBeInitiallyFalse() {
         XCTAssert(!PKHUD.sharedHUD.isVisible)
     }


### PR DESCRIPTION
I came here to fix the initial isVisible bug, but found it had already been taken care of in "fix: set isHidden to true on start for accurate status".  I had also written this unit test in my fix, so I offer it up here.