### PR TITLE
Fix add subview to UIVisualEffectView

### DIFF
--- a/PKHUD/FrameView.swift
+++ b/PKHUD/FrameView.swift
@@ -57,7 +57,7 @@ internal class FrameView: UIVisualEffectView {
             _content.clipsToBounds = true
             _content.contentMode = .center
             frame.size = _content.bounds.size
-            addSubview(_content)
+            contentView.addSubview(_content)
         }
     }
 }


### PR DESCRIPTION
As mentioned in title, add subview directly to visual view will cause exception on Xcode 9, iOS 11

```
2017-06-06 13:31:31.271621+0800 PKHUD Demo[23636:30988686] *** Assertion failure in -[PKHUD.FrameView _addSubview:positioned:relativeTo:], /BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit_Sim/UIKit-3678.13/UIVisualEffectView.m:1364
2017-06-06 13:31:31.274899+0800 PKHUD Demo[23636:30988686] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '<PKHUD.PKHUDProgressView: 0x7fba385047c0; frame = (0 0; 156 156); clipsToBounds = YES; alpha = 0.85; layer = <CALayer: 0x618000222b00>> has been added as a subview to <PKHUD.FrameView: 0x7fba387083d0; baseClass = UIVisualEffectView; frame = (0 0; 156 156); clipsToBounds = YES; autoresize = LM+RM+TM+BM; layer = <CALayer: 0x60000023a040>>. Do not add subviews directly to the visual effect view itself, instead add them to the -contentView.'
```
Could reproduce this with Sample Code, just click "Animated progress HUD".

Thanks for your great repo.