### PR TITLE
Allow more customization of PKHUDProgressView

### DIFF
--- a/PKHUD/PKHUDProgressView.swift
+++ b/PKHUD/PKHUDProgressView.swift
@@ -13,8 +13,12 @@ import QuartzCore
 /// PKHUDProgressView provides an indeterminate progress view.
 open class PKHUDProgressView: PKHUDSquareBaseView, PKHUDAnimating {
 
-    public init(title: String? = nil, subtitle: String? = nil) {
-        super.init(image: PKHUDAssets.progressActivityImage, title: title, subtitle: subtitle)
+    public init(frame: CGRect? = nil, image: UIImage = PKHUDAssets.progressActivityImage, title: String? = nil, subtitle: String? = nil) {
+        if let f = frame {
+            super.init(frame: f, image: image, title: title, subtitle: subtitle)
+        } else {
+            super.init(image: image, title: title, subtitle: subtitle)
+        }
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/PKHUD/PKHUDSquareBaseView.swift
+++ b/PKHUD/PKHUDSquareBaseView.swift
@@ -13,26 +13,27 @@ import UIKit
 open class PKHUDSquareBaseView: UIView {
 
     static let defaultSquareBaseViewFrame = CGRect(origin: CGPoint.zero, size: CGSize(width: 156.0, height: 156.0))
-
+    
     public override init(frame: CGRect) {
         super.init(frame: frame)
     }
-
+    
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-
-    public init(image: UIImage? = nil, title: String? = nil, subtitle: String? = nil) {
-        super.init(frame: PKHUDSquareBaseView.defaultSquareBaseViewFrame)
+    
+    public init(frame: CGRect = PKHUDSquareBaseView.defaultSquareBaseViewFrame, image: UIImage? = nil, title: String? = nil, subtitle: String? = nil) {
+        super.init(frame: frame)
+        
         self.imageView.image = image
         titleLabel.text = title
         subtitleLabel.text = subtitle
-
+        
         addSubview(imageView)
         addSubview(titleLabel)
         addSubview(subtitleLabel)
     }
-
+    
     open let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.alpha = 0.85


### PR DESCRIPTION
This PR adds more parameters to the initializers of PKHUDSquareBaseView and PKHUDProgressView.  All of the additional parameters are given default values so that the updated method signatures do not affect any existing code.
___
**PKHUDSquareBaseView**
The initializer was given a frame property so that the size of the view could be easily changed.

**PKHUDProgressView**
The initializer was given a frame and image property so that users could modify both the size and type of progress indicator.
___
**NOTE: THESE CHANGES DO NOT AFFECT EXISTING CODE.**

**THE VALUES OF FRAME WILL REMAIN THE SAME AS THEY WERE IF NONE IS PROVIDED IN THE INITIALIZER. (*PKHUDSquareBaseView.defaultSquareBaseViewFrame*)** 

**THE VALUE OF IMAGE WILL REMAIN THE SAME AS BEFORE IF NONE IS PROVIDED IN THE INITIALIZER. (*PKHUDAssets.progressActivityImage*)**