### PR TITLE
README: Use asyncAfter instead of delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can also hot-swap content views - this can prove useful if you want to displ
 HUD.show(.progress)
         
 // Now some long running task starts...
-delay(2.0) {
+DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
     // ...and once it finishes we flash the HUD for a second.
    HUD.flash(.success, delay: 1.0)
 }


### PR DESCRIPTION
When [this commit](https://github.com/pkluz/PKHUD/commit/154d147fa156430063ba5efb34f0574da6ab2df0#diff-04c6e90faac2675aa89e2176d2eec7d8R50) was done, it was too complicated to write a process like `delay`.
But now we can write it in one line.

By using the standard function you can prevent the question "What is `delay`?"

Please close this pull request if you do not like it. Thanks.