### PR TITLE
Adds margin for subviews in square baseView

### DIFF
--- a/PKHUD/HUD.swift
+++ b/PKHUD/HUD.swift
@@ -39,7 +39,17 @@ public final class HUD {
         get { return PKHUD.sharedHUD.userInteractionOnUnderlyingViewsEnabled  }
         set { PKHUD.sharedHUD.userInteractionOnUnderlyingViewsEnabled = newValue }
     }
+    
+    public static var leadingMargin: CGFloat {
+        get { return PKHUD.sharedHUD.leadingMargin  }
+        set { PKHUD.sharedHUD.leadingMargin = newValue }
+    }
 
+    public static var trailingMargin: CGFloat {
+        get { return PKHUD.sharedHUD.trailingMargin  }
+        set { PKHUD.sharedHUD.trailingMargin = newValue }
+    }
+    
     public static var isVisible: Bool { return PKHUD.sharedHUD.isVisible }
 
     // MARK: Public methods, PKHUD based

--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -117,6 +117,10 @@ open class PKHUD: NSObject {
             container.frameView.effect = newValue
         }
     }
+    
+    open var leadingMargin: CGFloat = 0
+    
+    open var trailingMargin: CGFloat = 0
 
     open func show(onView view: UIView? = nil) {
         let view: UIView = view ?? viewToPresentOn ?? UIApplication.shared.keyWindow!

--- a/PKHUD/PKHUDSquareBaseView.swift
+++ b/PKHUD/PKHUDSquareBaseView.swift
@@ -66,15 +66,18 @@ open class PKHUDSquareBaseView: UIView {
     open override func layoutSubviews() {
         super.layoutSubviews()
 
-        let viewWidth = bounds.size.width
+        let margin: CGFloat = PKHUD.sharedHUD.leadingMargin + PKHUD.sharedHUD.trailingMargin
+        let originX: CGFloat = margin > 0 ? margin : 0.0
+        let viewWidth = bounds.size.width - 2 * margin
         let viewHeight = bounds.size.height
 
         let halfHeight = CGFloat(ceilf(CFloat(viewHeight / 2.0)))
         let quarterHeight = CGFloat(ceilf(CFloat(viewHeight / 4.0)))
         let threeQuarterHeight = CGFloat(ceilf(CFloat(viewHeight / 4.0 * 3.0)))
 
-        titleLabel.frame = CGRect(origin: CGPoint.zero, size: CGSize(width: viewWidth, height: quarterHeight))
-        imageView.frame = CGRect(origin: CGPoint(x: 0.0, y: quarterHeight), size: CGSize(width: viewWidth, height: halfHeight))
-        subtitleLabel.frame = CGRect(origin: CGPoint(x: 0.0, y: threeQuarterHeight), size: CGSize(width: viewWidth, height: quarterHeight))
+        titleLabel.frame = CGRect(origin: CGPoint(x: originX, y: 0.0), size: CGSize(width: viewWidth, height: quarterHeight))
+        imageView.frame = CGRect(origin: CGPoint(x: originX, y: quarterHeight), size: CGSize(width: viewWidth, height: halfHeight))
+        subtitleLabel.frame = CGRect(origin: CGPoint(x: originX, y: threeQuarterHeight), size: CGSize(width: viewWidth, height: quarterHeight))
+        
     }
 }


### PR DESCRIPTION
Added some leading and trailing margin for the textLables title and subtitle (and the imageView).

So instead of this:
![simulator screen shot - iphone 6 - 2018-07-07 at 12 26 16 | width=48](https://user-images.githubusercontent.com/13586174/42409907-15d0ea0a-81e1-11e8-8279-a23df6f92cd3.png)

We'll get this:
![simulator screen shot - iphone 6 - 2018-07-07 at 12 25 55](https://user-images.githubusercontent.com/13586174/42409911-1d66c3a2-81e1-11e8-9232-ceb1c677f97d.png)