### PR TITLE
Add compatibility to Swift 4.2 on Xcode 10 GM

### DIFF
--- a/PKHUD/PKHUD.swift
+++ b/PKHUD/PKHUD.swift
@@ -138,7 +138,11 @@ open class PKHUD: NSObject {
         // If the grace time is set, postpone the HUD display
         if gracePeriod > 0.0 {
             let timer = Timer(timeInterval: gracePeriod, target: self, selector: #selector(PKHUD.handleGraceTimer(_:)), userInfo: nil, repeats: false)
+            #if swift(>=4.2)
+            RunLoop.current.add(timer, forMode: .common)
+            #else
             RunLoop.current.add(timer, forMode: .commonModes)
+            #endif
             graceTimer = timer
         } else {
             showContent()

--- a/PKHUD/PKHUDSystemActivityIndicatorView.swift
+++ b/PKHUD/PKHUDSystemActivityIndicatorView.swift
@@ -40,7 +40,11 @@ public final class PKHUDSystemActivityIndicatorView: PKHUDSquareBaseView, PKHUDA
     }
 
     let activityIndicatorView: UIActivityIndicatorView = {
+        #if swift(>=4.2)
+        let activity = UIActivityIndicatorView(style: .whiteLarge)
+        #else
         let activity = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
+        #endif
         activity.color = UIColor.black
         return activity
     }()


### PR DESCRIPTION
Fixed the 2 errors thrown by Xcode 10 GM on 5.1.0 version of PKHUD with Swift version set to 4.2.

Both fixes required minimal changes (just one init and one enum that got renamed).