### PR TITLE
Switch podspec to use resource bundle for asset catalog

### DIFF
--- a/PKHUD.podspec
+++ b/PKHUD.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.requires_arc              = true
   s.source                    = { :git => 'https://github.com/pkluz/PKHUD.git', :tag => s.version.to_s }
   s.source_files              = 'PKHUD/**/*.{h,swift}'
-  s.resources                 = 'PKHUD/*.xcassets'
+  s.resource_bundle           = { 'PKHUDResources' => 'PKHUD/*.xcassets' }
 end

--- a/PKHUD/PKHUDAssets.swift
+++ b/PKHUD/PKHUDAssets.swift
@@ -18,9 +18,16 @@ open class PKHUDAssets: NSObject {
     open class var progressCircularImage: UIImage { return PKHUDAssets.bundledImage(named: "progress_circular") }
 
     internal class func bundledImage(named name: String) -> UIImage {
-        let bundle = Bundle(for: PKHUDAssets.self)
-        let image = UIImage(named: name, in: bundle, compatibleWith: nil)
-        if let image = image {
+        let primaryBundle = Bundle(for: PKHUDAssets.self)
+        if let image = UIImage(named: name, in: primaryBundle, compatibleWith: nil) {
+            // Load image in cases where PKHUD is directly integrated
+            return image
+        } else if
+            let subBundleUrl = primaryBundle.url(forResource: "PKHUDResources", withExtension: "bundle"),
+            let subBundle = Bundle(url: subBundleUrl),
+            let image = UIImage(named: name, in: subBundle, compatibleWith: nil)
+        {
+            // Load image in cases where PKHUD is integrated via cocoapods as a dynamic or static framework with a separate resource bundle
             return image
         }
 


### PR DESCRIPTION
The way Cocoapods integrates asset catalogs from pods that don't use resource bundles into apps is currently slightly broken and unnecessarily increases build times. Cocoapods essentially recompiles the app's main asset catalog to include all asset catalogs from pods, but the process is not reliable and has to be done on every build, even if nothing's changed.

This PR switches PKHUD to using resources bundles instead.

I've tested the changes with the demo project, Carthage, and Cocoapods using both dynamic and static frameworks and didn't find any issues.