### PR TITLE
Silence warning about implicitly final properties

### DIFF
--- a/PKHUD/PKHUDTextView.swift
+++ b/PKHUD/PKHUDTextView.swift
@@ -34,7 +34,7 @@ open class PKHUDTextView: PKHUDWideBaseView {
         titleLabel.frame = bounds.insetBy(dx: padding, dy: padding)
     }
 
-    open let titleLabel: UILabel = {
+    public let titleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
         label.font = UIFont.boldSystemFont(ofSize: 17.0)


### PR DESCRIPTION
> 'let' properties are implicitly 'final'; use 'public' instead of 'open'