### PR TITLE
Fix SPM resource

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
 // swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -19,6 +20,9 @@ let package = Package(
             path: "PKHUD",
             exclude: [
                 "Info.plist",
+            ],
+            resources: [
+                .process("Images.xcassets")
             ]
         ),
     ],


### PR DESCRIPTION
Fix Bundle.module is not generated for external SPM dependency
`Type 'Bundle?' has no member 'module''`